### PR TITLE
logging.PercentStyle not available in Python 2.7

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,15 @@ master
 
 `View commits since the last tag <https://github.com/sdss/python_template/compare/1.0.3...HEAD>`__.
 
+.. _changelog-1.0.5:
+
+1.0.5 (2019-04-09)
+------------------
+
+Fixed
+^^^^^
+* Bug causing Python 2.7 templates to fail because ``PercentStyle`` is not available in ``logging`` module.
+
 
 .. _changelog-1.0.4:
 

--- a/{{cookiecutter.repo_name}}/python/{{cookiecutter.package_name|lower}}/utils/logger.py
+++ b/{{cookiecutter.repo_name}}/python/{{cookiecutter.package_name|lower}}/utils/logger.py
@@ -18,7 +18,27 @@ import shutil
 import sys
 import traceback
 import warnings
-from logging import PercentStyle
+try:
+    from logging import PercentStyle
+
+except NameError:
+    # PercentStyle not available in Python 2.7
+
+    class PercentStyle(object):
+
+        default_format = '%(message)s'
+        asctime_format = '%(asctime)s'
+        asctime_search = '%(asctime)'
+
+        def __init__(self, fmt):
+            self._fmt = fmt or self.default_format
+
+        def usesTime(self):
+            return self._fmt.find(self.asctime_search) >= 0
+
+        def format(self, record):
+            return self._fmt.format(**record.__dict__)
+    
 from logging.handlers import TimedRotatingFileHandler
 
 from pygments import highlight


### PR DESCRIPTION
Hi,

``logging.PercentStyle`` is not available in Python 2.7, causing the Travis build to fail when using a clean version of ``python_template``. A failed build is [available here](https://travis-ci.org/sdss/astra/jobs/517495600). 

This is a proposed fix that incorporates the ``PercentStyle`` object if it cannot be incorporated from the ``logging`` module.